### PR TITLE
Add variants of InvokeStates which accept Action<State> and Func<Stat…

### DIFF
--- a/src/Hsm.cs
+++ b/src/Hsm.cs
@@ -592,6 +592,26 @@ namespace Hsm
             InvokeStates(aMethodName, aArgs, CreateReverseIterator(mStateStack));
         }
 
+        public void InvokeOuterToInner(Action<State> aLambda)
+        {
+            InvokeStates(aLambda, mStateStack);
+        }
+
+        public void InvokeInnerToOuter(Action<State> aLambda)
+        {
+            InvokeStates(aLambda, CreateReverseIterator(mStateStack));
+        }
+        
+        public void InvokeOuterToInner(Func<State, bool> aLambda)
+        {
+            InvokeStates(aLambda, mStateStack);
+        }
+
+        public void InvokeInnerToOuter(Func<State, bool> aLambda)
+        {
+            InvokeStates(aLambda, CreateReverseIterator(mStateStack));
+        }
+
         // PRIVATE
 
         static private IEnumerable<T> CreateReverseIterator<T>(IList<T> aList)
@@ -618,13 +638,31 @@ namespace Hsm
                 MethodInfo methodInfo = state.GetType().GetMethod(aMethodName);
                 if (methodInfo != null)
                 {
-                    bool keepGoing = (bool)methodInfo.Invoke(state, aArgs);
+                    var keepGoing = (bool)methodInfo.Invoke(state, aArgs);
                     if (!keepGoing)
                         return;
                 }
             }
         }
 
+        private void InvokeStates(Action<State> aLambda, IEnumerable<State> aEnumerable)
+        {
+            foreach (State state in aEnumerable)
+            {
+                aLambda(state);
+            }
+        }
+
+        private void InvokeStates(Func<State, bool> aLambda, IEnumerable<State> aEnumerable)
+        {
+            foreach (State state in aEnumerable)
+            {
+                var keepGoing = aLambda(state);
+                if (!keepGoing)
+                    return;
+            }
+        }
+        
         private void LogTransition(TraceLevel aTraceLevel, int aDepth, string aTransitionName, Type aTargetStateType)
         {
             if (mTraceLevel < aTraceLevel)


### PR DESCRIPTION
…e, bool>

This is convenient with modern C#'s lambda functions, and it obviates the need for reflection as employed in the classic InvokeStates().